### PR TITLE
Added readme to project

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,0 +1,56 @@
+# Observer Notification Bulk set
+
+With large sets of users added into canvas, it is possible that you have large counts of parent observers. The default settings for notifications is far too comprehensive, meaning that parents receive notifications for almost every activity on canvas. This is not desirable, particularly as default behavior. 
+
+## Purpose of the script
+
+This script changes the notification settings for user groups on canvas. The use case for my institution was to change the notification status of parent observers for canvas. Parents were being notified for every action on canvas, and possibly for multiple courses at the same time. 
+
+The script iterated through all courses offered in a term, identified the observers, then changed their notification status to the desired setting. 
+
+## Dependencies
+
+This script relies on: 
+
+ - Logging
+ - Threading
+ - OS
+ - SYS
+ - time
+ - itertools
+ - requests
+
+ Externals:
+ - [dotenv](https://pypi.org/project/python-dotenv/)
+ - [canvasapi](https://canvasapi.readthedocs.io/en/stable/getting-started.html)
+
+## Configuration options
+
+### ENVIRONMENT FILE
+
+The environment file contains basic configuration options which are set for the project. This file is loaded at he beginning of the program. Most important, is the `CANVAS_URL` and `CANVAS_API_KEY` these two constants direct the program to the canvas instance, and provides the API key for authentication. 
+
+### Headers
+
+Headers provided to canvas. These are standard and used with any request when made to canvas. This draws from the `.env` file.
+
+### Timeout Seconds
+
+Used to customise the timeout used by the requests module. If a request takes longer than the timeout, it will be considered a failed connection. **DEFAULTS** to 5 seconds
+
+### Notification options
+
+Python dictionary of notification options, allows for the user to customise what type of notifications are given to observers. Options are as follows:
+
+- **Never**: Never notify
+- **Immediately**: Notify user immediately
+- **Daily**: daily summary notification
+- **Weekly**: Weekly summary notification 
+
+This dictionary is used to pick which option is provided to the API, it is set in the `.env` file. 
+
+## Enrolment types
+
+**NOTE this is subjective to your installation**
+It is very likely that you have different enrolment types in your system. For the system this was deployed on, `observers` were the user type which was being targeted. Therefore, this was the only user type that was targeted. 
+You might need to do more research on your own instance to ascertain what group of users you are targeting. You can then modify the dictionary to include these items.

--- a/readme.md
+++ b/readme.md
@@ -8,6 +8,21 @@ This script changes the notification settings for user groups on canvas. The use
 
 The script iterated through all courses offered in a term, identified the observers, then changed their notification status to the desired setting. 
 
+## Contents
+
+ - [Dependancies](#dependencies)
+ - [Configuration Options](#configuration-options)
+    - [Env file](#environment-file)
+    - [Headers](#headers)
+    - [Time Outs](#timeout-seconds)
+    - [Notification Options](#notification-options)
+    - [Enrolment Types](#enrolment-types)
+    - [Excluded notifications](#excluded-notifications)
+    - [Canvas Account](#canvas-account)
+    - [Log levels](#log-levels)
+    - [Max Threads](#max-threads)
+ - [Command line arguments](#command-line-arguments)
+
 ## Dependencies
 
 This script relies on: 
@@ -49,8 +64,35 @@ Python dictionary of notification options, allows for the user to customise what
 
 This dictionary is used to pick which option is provided to the API, it is set in the `.env` file. 
 
-## Enrolment types
+### Enrolment types
 
 **NOTE this is subjective to your installation**
 It is very likely that you have different enrolment types in your system. For the system this was deployed on, `observers` were the user type which was being targeted. Therefore, this was the only user type that was targeted. 
 You might need to do more research on your own instance to ascertain what group of users you are targeting. You can then modify the dictionary to include these items.
+
+### Excluded notifications
+
+This tuple of text values aligns with the notifications which you may wish to exclude from being affected. This can allow you to turn of or affect a particular subset of communications within the canvas system, and leave other more critical comms to the default behaviour. 
+
+### Canvas account
+
+As this system is usually performed from an admin perspective, within canvas, an account is needed for impersonation. The account chosen as a default `1`, is the admin account for the instance this was tested on; It may be different for your particular use case. This account needs to have access to the [term](https://canvas.instructure.com/doc/api/enrollment_terms.html) you are examining. For example, if you are deactivating notifications for 2024 Term 3 Senior school, then the impersonated account needs this access. To ensure this, impersonate the highest level admin account you have access or permission for. 
+
+### Log levels
+
+This allows you to set the different levels of logging. The **Default** is `INFO` which outputs only informational, and above, messages. This can be adjusted if you need more detail from logging, if `DEBUG` is chosen then the requests module may also emit messages. 
+
+The options available are:
+ - DEBUG
+ - INFO
+ - WARNING
+ - ERROR
+ - CRITICAL
+
+### Max Threads 
+
+If your program is causing your computer to melt down, or you are rate-limiting with canvas, this variable should be reduced. Generally, 10 threads is acceptable, and doesn't cause too much fuss on modern systems. 
+This program is regularly run on an old (2015) i5 Processor, though it was developed on a modern macintosh. Depending on your setup you may need to suit this to your taste. 
+
+## Command line arguments
+

--- a/readme.md
+++ b/readme.md
@@ -105,3 +105,9 @@ The values which are read from the command line, which are comma separated, are 
 As the script may be run on a single term, or the script may be run on multiple terms from another program -- this data is entered through the command line. 
 
 Term IDs can be found in the canvas dashboards and through the URL's which are used to access data within that term. More info can be found [Here](https://community.canvaslms.com/t5/Admin-Guide/How-do-I-use-the-Terms-page-in-an-account/ta-p/159)
+
+### Example
+
+``` 
+$: python3 Update_observers_notifications.py 4,144
+```

--- a/readme.md
+++ b/readme.md
@@ -96,3 +96,12 @@ This program is regularly run on an old (2015) i5 Processor, though it was devel
 
 ## Command line arguments
 
+In addition to the environment file, the script also consumes command line arguments. Generally this is done as the script may be run with `.env` values multiple times, but the command line allows for rapid changing of values that may need to be separated. 
+
+### TERM IDs
+
+The values which are read from the command line, which are comma separated, are the term ids which need to be updated. 
+
+As the script may be run on a single term, or the script may be run on multiple terms from another program -- this data is entered through the command line. 
+
+Term IDs can be found in the canvas dashboards and through the URL's which are used to access data within that term. More info can be found [Here](https://community.canvaslms.com/t5/Admin-Guide/How-do-I-use-the-Terms-page-in-an-account/ta-p/159)


### PR DESCRIPTION
With the project being made public, a readme is needed for users who may not be familiar with the script and do not want to read the code. 

The readme should guide a user on sensible defaults and what each of the configuration options are used for